### PR TITLE
Set st_size for directories too

### DIFF
--- a/GMUserFileSystem.m
+++ b/GMUserFileSystem.m
@@ -860,13 +860,9 @@ static const int kWaitForMountUSleepInterval = 100000;  // 100 ms
   }
 #endif
 
-  // Size for regular files.
-  // TODO: Revisit size for directories.
-  if (![fileType isEqualToString:NSFileTypeDirectory]) {
-    NSNumber* size = [attributes objectForKey:NSFileSize];
-    if (size) {
-      stbuf->st_size = [size longLongValue];
-    }
+  NSNumber* size = [attributes objectForKey:NSFileSize];
+  if (size) {
+    stbuf->st_size = [size longLongValue];
   }
 
   // Set the number of blocks used so that Finder will display size on disk 


### PR DESCRIPTION
I've recently encountered problems with a filesystem I implemented in objective-C.
Turns out that the fact that `st_size` is set to 0 for directories made some external components act up.

I think this change should be put in the code because it's better to be consistent between the C API and the Obj-C API.
If you look at the looopback examples, you will see that they behave differently for directories.