### PR TITLE
Added contextPid

### DIFF
--- a/GMUserFileSystem.h
+++ b/GMUserFileSystem.h
@@ -152,6 +152,8 @@ GM_EXPORT @interface GMUserFileSystem : NSObject {
  */
 - (void)unmount;
 
++ (pid_t *)contextPid;
+
 @end
 
 #pragma mark Notifications

--- a/GMUserFileSystem.m
+++ b/GMUserFileSystem.m
@@ -354,6 +354,12 @@ typedef enum {
   return (GMUserFileSystem *)context->private_data;
 }
 
++ (pid_t *)contextPid {
+  struct fuse_context* context = fuse_get_context();
+  assert(context);
+  return context->pid;
+}
+
 #define FUSEDEVIOCGETHANDSHAKECOMPLETE _IOR('F', 2, u_int32_t)
 static const int kMaxWaitForMountTries = 50;
 static const int kWaitForMountUSleepInterval = 100000;  // 100 ms


### PR DESCRIPTION
Context pid (meaning, the process that triggered the filesystem call) is very useful in order to implement our own filesystem with custom behavior.

See my Google Group thread on the subject:
https://groups.google.com/forum/?hl=en#!topic/osxfuse-group/9oso7jWTjAw