### PR TITLE
Use -fileSystemRepresentation instead of -UTF8String

### DIFF
--- a/GMUserFileSystem.m
+++ b/GMUserFileSystem.m
@@ -1778,7 +1778,7 @@ static int fusefm_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
       filler(buf, ".", NULL, 0);
       filler(buf, "..", NULL, 0);
       for (int i = 0, count = [contents count]; i < count; i++) {
-        filler(buf, [[contents objectAtIndex:i] UTF8String], NULL, 0);
+        filler(buf, [[contents objectAtIndex:i] fileSystemRepresentation], NULL, 0);
       }
     } else {
       MAYBE_USE_ERROR(ret, error);


### PR DESCRIPTION
Updated fusefm_readdir to use -[NSString fileSystemRepresentation] to convert to C-strings. Using -[NSString UTF8String] can cause issues with duplicated folder/file names in Finder if the name contains accented characters due to Unicode normalization.

I believe this to resolve issue: https://github.com/osxfuse/osxfuse/issues/460. I was seeing the same behavior and this change resolves it.